### PR TITLE
Add o1 Reasoning Traces Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ format:
 - [Maitrix.org] [LLM Reasoners](https://github.com/maitrix-org/llm-reasoners)
 - [bklieger-groq] [g1: Using Llama-3.1 70b on Groq to create o1-like reasoning chains](https://github.com/bklieger-groq/g1)
 - [toyberry] [Toyberry: A end to end tiny implementation of OpenAI's o1 reasoning system using MCTS and LLM as backend](https://github.com/ack-sec/toyberry)
+- [o1-chain-of-thought] [Transcription of o1 Reasoning Traces from OpenAI blog post](https://github.com/bradhilton/o1-chain-of-thought)
 
 ## Evaluation
 - ~~[AryanDLuffy] [Codeforces - O1-mini benchmark](https://codeforces.com/blog/entry/133962)~~


### PR DESCRIPTION
I compiled the reasoning traces from OpenAI's blog post and put them in [this repository](https://github.com/bradhilton/o1-chain-of-thought) as easily digestible markdown files. I think it might be a useful resource for anyone wanting to leverage the little we have in terms of o1 reasoning traces that are either summarized at a high level in ChatGPT or completely unavailable via the API.