### PR TITLE
Add related paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ format:
 ### 2024
 - [GSM-Symbolic: Understanding the Limitations of Mathematical Reasoning in Large Language Models](https://arxiv.org/abs/2410.05229)
   - Iman Mirzadeh, Keivan Alizadeh, Hooman Shahrokhi, Oncel Tuzel, Samy Bengio, Mehrdad Farajtabar
+- [VinePPO: Unlocking RL Potential For LLM Reasoning Through Refined Credit Assignment](https://arxiv.org/abs/2410.01679)
+  - Amirhossein Kazemnejad, Milad Aghajohari, Eva Portelance, Alessandro Sordoni, Siva Reddy, Aaron Courville, Nicolas Le Roux
 - [Evaluation of OpenAI o1: Opportunities and Challenges of AGI](https://arxiv.org/abs/2409.18486)
   - Tianyang Zhong, Zhengliang Liu, Yi Pan, Yutong Zhang, Yifan Zhou, Shizhe Liang, Zihao Wu, Yanjun Lyu, Peng Shu, Xiaowei Yu, Chao Cao, Hanqi Jiang, Hanxu Chen, Yiwei Li, Junhao Chen, etc.
 - [Planning In Natural Language Improves LLM Search For Code Generation](https://arxiv.org/abs/2409.03733)


### PR DESCRIPTION
Hi!

Thanks a lot for creating this list. It looks quite comprehensive.

I'm opening this to suggest our recent paper on LLM reasoning through proper RL.

In VinePPO, we show how train-time compute scaling of o1 could work. We show that increasing LLM inference (to reduce value estimation variance) during RL training directly improve test-time accuracy.

Here is the paper:
https://arxiv.org/abs/2409.18486

Here's our discussion on Twitter (with Nathan Lambert):
https://x.com/natolambert/status/1841926635966091280