### PR TITLE
Add AI Models Catalog — 1,306 reasoning models with pricing & capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ And the repository will be continuously updated to track the frontier of LLM Rea
 - [NVIDIA] [Nemotron-Research-Reasoning-Qwen-1.5B](https://huggingface.co/nvidia/Nemotron-Research-Reasoning-Qwen-1.5B)
 - [Skywork] [Skywork R1V2](https://huggingface.co/collections/Skywork/skywork-r1v2-68075a3d947a5ae160272671)
 - [rLLM] [DeepScaler](https://github.com/agentica-project/rllm)
+- [AI Models Catalog] [1,306 reasoning models with pricing & capabilities](https://github.com/i-need-token/ai-models) — Structured YAML catalog of reasoning models across 95 providers
 - [NovaSky] [Sky-T1](https://github.com/NovaSky-AI/SkyThought)
 - [GAIR-NLP] [O1 Replication Journey: A Strategic Progress Report](https://github.com/GAIR-NLP/O1-Journey)
 - [OpenO1 Team] [Open-Source O1](https://opensource-o1.github.io/)

--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ format:
 
 ### 2025
 - [Nemotron-Cascade: Scaling Cascaded Reinforcement Learning for General-Purpose Reasoning Models](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Nano-Technical-Report.pdf)
-  - NVIDIA 
+  - NVIDIA
 - [QwenLong-L1.5: Post-Training Recipe for Long-Context Reasoning and Memory](https://www.arxiv.org/abs/2512.12967)
-  - Qwen Team 
+  - Qwen Team
 - [DeepSeekMath-V2: Towards Self-Verifiable Mathematical Reasoning](https://arxiv.org/pdf/2511.22570v1)
-  - DeepSeek-AI 
+  - DeepSeek-AI
 - [Stabilizing Reinforcement Learning with LLMs: Formulation and Practices](https://arxiv.org/pdf/2512.01374)
   - Qwen Team
 - [The Art of Scaling Reinforcement Learning Compute for LLMs](https://arxiv.org/abs/2510.13786)
-  - Devvrit Khatri, Lovish Madaan, Rishabh Tiwari, Rachit Bansal, Sai Surya Duvvuri, Manzil Zaheer, Inderjit S. Dhillon, David Brandfonbrener, Rishabh Agarwal 
+  - Devvrit Khatri, Lovish Madaan, Rishabh Tiwari, Rachit Bansal, Sai Surya Duvvuri, Manzil Zaheer, Inderjit S. Dhillon, David Brandfonbrener, Rishabh Agarwal
 - [BroRL: Scaling Reinforcement Learning via Broadened Exploration](https://arxiv.org/abs/2510.01180)
   - Jian Hu, Mingjie Liu, Ximing Lu, Fang Wu, Zaid Harchaoui, Shizhe Diao, Yejin Choi, Pavlo Molchanov, Jun Yang, Jan Kautz, Yi Dong
 - [Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)


### PR DESCRIPTION
Hi! I'd like to add the [AI Models Catalog](https://github.com/i-need-token/ai-models) to the Models section.

**What it is:** A structured YAML catalog of 4,587+ AI models across 95 providers, with first-party data on pricing, context windows, modalities, and capabilities. It includes **1,306 reasoning models** with detailed metadata.

**Why it's useful for this list:** Developers researching reasoning models can use the catalog to:
- Compare reasoning models by pricing (e.g., DeepSeek R1 at $0.55/$2.19 vs o3 at $2/$8)
- Filter by reasoning + tool calling + structured output combinations
- Find free reasoning models for prototyping
- Browse [interactive comparison pages](https://i-need-token.github.io/ai-models/reasoning-models-comparison.html)

**Data quality:** All data sourced from first-party APIs, validated with Zod schemas, updated automatically via CI.

Thanks for considering!