### PR TITLE
Add AI Models Catalog — reasoning models with pricing & capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ And the repository will be continuously updated to track the frontier of LLM Rea
 - [NVIDIA] [Nemotron-Research-Reasoning-Qwen-1.5B](https://huggingface.co/nvidia/Nemotron-Research-Reasoning-Qwen-1.5B)
 - [Skywork] [Skywork R1V2](https://huggingface.co/collections/Skywork/skywork-r1v2-68075a3d947a5ae160272671)
 - [rLLM] [DeepScaler](https://github.com/agentica-project/rllm)
+- [AI Models Catalog] [Reasoning models with pricing & capabilities](https://github.com/i-need-token/ai-models) — Structured YAML catalog of AI models across providers
 - [NovaSky] [Sky-T1](https://github.com/NovaSky-AI/SkyThought)
 - [GAIR-NLP] [O1 Replication Journey: A Strategic Progress Report](https://github.com/GAIR-NLP/O1-Journey)
 - [OpenO1 Team] [Open-Source O1](https://opensource-o1.github.io/)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ And the repository will be continuously updated to track the frontier of LLM Rea
 - [NVIDIA] [Nemotron-Research-Reasoning-Qwen-1.5B](https://huggingface.co/nvidia/Nemotron-Research-Reasoning-Qwen-1.5B)
 - [Skywork] [Skywork R1V2](https://huggingface.co/collections/Skywork/skywork-r1v2-68075a3d947a5ae160272671)
 - [rLLM] [DeepScaler](https://github.com/agentica-project/rllm)
-- [AI Models Catalog] [Reasoning models with pricing & capabilities](https://github.com/i-need-token/ai-models) — Structured YAML catalog of AI models across providers
 - [NovaSky] [Sky-T1](https://github.com/NovaSky-AI/SkyThought)
 - [GAIR-NLP] [O1 Replication Journey: A Strategic Progress Report](https://github.com/GAIR-NLP/O1-Journey)
 - [OpenO1 Team] [Open-Source O1](https://opensource-o1.github.io/)
@@ -123,6 +122,9 @@ And the repository will be continuously updated to track the frontier of LLM Rea
 - [Sea AI Lab] [Dr. GRPO](https://github.com/sail-sg/understand-r1-zero)
 - [Berkeley AI Research] [TinyZero](https://github.com/Jiayi-Pan/TinyZero)
 - [Maitrix.org] [LLM Reasoners](https://github.com/maitrix-org/llm-reasoners)
+
+### Resources
+- [i-need-token] [AI Models Catalog](https://github.com/i-need-token/ai-models) — Structured YAML catalog of reasoning models with pricing and capabilities
 
 ## Papers
 

--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ format:
 
 ### 2025
 - [Nemotron-Cascade: Scaling Cascaded Reinforcement Learning for General-Purpose Reasoning Models](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Nano-Technical-Report.pdf)
-  - NVIDIA 
+  - NVIDIA
 - [QwenLong-L1.5: Post-Training Recipe for Long-Context Reasoning and Memory](https://www.arxiv.org/abs/2512.12967)
-  - Qwen Team 
+  - Qwen Team
 - [DeepSeekMath-V2: Towards Self-Verifiable Mathematical Reasoning](https://arxiv.org/pdf/2511.22570v1)
-  - DeepSeek-AI 
+  - DeepSeek-AI
 - [Stabilizing Reinforcement Learning with LLMs: Formulation and Practices](https://arxiv.org/pdf/2512.01374)
   - Qwen Team
 - [The Art of Scaling Reinforcement Learning Compute for LLMs](https://arxiv.org/abs/2510.13786)
-  - Devvrit Khatri, Lovish Madaan, Rishabh Tiwari, Rachit Bansal, Sai Surya Duvvuri, Manzil Zaheer, Inderjit S. Dhillon, David Brandfonbrener, Rishabh Agarwal 
+  - Devvrit Khatri, Lovish Madaan, Rishabh Tiwari, Rachit Bansal, Sai Surya Duvvuri, Manzil Zaheer, Inderjit S. Dhillon, David Brandfonbrener, Rishabh Agarwal
 - [BroRL: Scaling Reinforcement Learning via Broadened Exploration](https://arxiv.org/abs/2510.01180)
   - Jian Hu, Mingjie Liu, Ximing Lu, Fang Wu, Zaid Harchaoui, Shizhe Diao, Yejin Choi, Pavlo Molchanov, Jun Yang, Jan Kautz, Yi Dong
 - [Why Language Models Hallucinate](https://openai.com/index/why-language-models-hallucinate/)


### PR DESCRIPTION
Adds [AI Models Catalog](https://github.com/i-need-token/ai-models) to the Models section — a structured YAML catalog of AI models across providers with pricing, context windows, and capabilities.

Updated per review feedback: removed specific model/provider counts to improve maintainability and prevent information from becoming outdated.